### PR TITLE
Rjdev

### DIFF
--- a/barcodex/__init__.py
+++ b/barcodex/__init__.py
@@ -985,7 +985,9 @@ def extract_barcodes_separate(r1_in, prefix, ru_in, r2_in=None, separator='_', u
         
     # check if list of accepted barcodes provides
     if umilist:
-        barcodes = _get_valid_barcodes(umilist)
+        infile = open(umilist)
+        barcodes = list(map(lambda x: x.strip(), infile.read().rstrip().split('\n')))
+        infile.close()
     
     # count all reads and reads with matching and non-matching patterns
     Total, Matching, NonMatching, Rejected = 0, 0, 0, 0

--- a/barcodex/__init__.py
+++ b/barcodex/__init__.py
@@ -1333,39 +1333,41 @@ def main():
     
     args = parser.parse_args()
     
-    if args.extract_subparser_name == 'inline':
-        try:
-            extract_barcodes_inline(args.r1_in, pattern1=args.pattern1, prefix=args.prefix, pattern2=args.pattern2, 
-                                    r2_in=args.r2_in, separator=args.separator, umilist=args.umilist)
-        except AttributeError as e:
-            print('#############\n')
-            print('AttributeError: {0}\n'.format(e))
-            print('#############\n\n')
-            print(parser.format_help())
-    elif args.extract_subparser_name == 'separate':
-        try:
-            extract_barcodes_separate(args.r1_in, prefix=args.prefix, ru_in=args.ru_in, r2_in=args.r2_in, separator=args.separator, umilist=args.umilist)
-        except AttributeError as e:
-            print('#############\n')
-            print('AttributeError: {0}\n'.format(e))
-            print('#############\n\n')
-            print(parser.format_help())
-    elif args.restore_subparser_name == 'inline':
-        try:
-            reconstruct_fastqs_inline(args.prefix, args.separator, args.umi_pos, args.r1_processed, r1_extracted=args.r1_extracted, r1_discarded=args.r1_discarded, r2_processed=args.r2_processed, r2_extracted=args.r2_extracted, r2_discarded=args.r2_discarded)
-        except AttributeError as e:
-            print('#############\n')
-            print('AttributeError: {0}\n'.format(e))
-            print('#############\n\n')
-            print(parser.format_help())
-    elif args.restore_subparser_name == 'separate':
-        try:
-            reconstruct_fastqs_separate(args.prefix, args.separator, args.r1_processed, args.umi_extracted, r1_discarded=args.r1_discarded, r2_processed=args.r2_processed, r2_discarded=args.r2_discarded, umi_discarded=args.umi_discarded)
-        except AttributeError as e:
-            print('#############\n')
-            print('AttributeError: {0}\n'.format(e))
-            print('#############\n\n')
-            print(parser.format_help())
+    if args.subparser_name == 'extract':
+        if args.extract_subparser_name == 'inline':
+            try:
+                extract_barcodes_inline(args.r1_in, pattern1=args.pattern1, prefix=args.prefix, pattern2=args.pattern2, 
+                                        r2_in=args.r2_in, separator=args.separator, umilist=args.umilist)
+            except AttributeError as e:
+                print('#############\n')
+                print('AttributeError: {0}\n'.format(e))
+                print('#############\n\n')
+                print(parser.format_help())
+        elif args.extract_subparser_name == 'separate':
+            try:
+                extract_barcodes_separate(args.r1_in, prefix=args.prefix, ru_in=args.ru_in, r2_in=args.r2_in, separator=args.separator, umilist=args.umilist)
+            except AttributeError as e:
+                print('#############\n')
+                print('AttributeError: {0}\n'.format(e))
+                print('#############\n\n')
+                print(parser.format_help())
+    elif args.subparser_name == 'restore':
+        if args.restore_subparser_name == 'inline':
+            try:
+                reconstruct_fastqs_inline(args.prefix, args.separator, args.umi_pos, args.r1_processed, r1_extracted=args.r1_extracted, r1_discarded=args.r1_discarded, r2_processed=args.r2_processed, r2_extracted=args.r2_extracted, r2_discarded=args.r2_discarded)
+            except AttributeError as e:
+                print('#############\n')
+                print('AttributeError: {0}\n'.format(e))
+                print('#############\n\n')
+                print(parser.format_help())
+        elif args.restore_subparser_name == 'separate':
+            try:
+                reconstruct_fastqs_separate(args.prefix, args.separator, args.r1_processed, args.umi_extracted, r1_discarded=args.r1_discarded, r2_processed=args.r2_processed, r2_discarded=args.r2_discarded, umi_discarded=args.umi_discarded)
+            except AttributeError as e:
+                print('#############\n')
+                print('AttributeError: {0}\n'.format(e))
+                print('#############\n\n')
+                print(parser.format_help())
     elif args.subparser_name is None:
         print(parser.format_help())
     

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ Created on Fri Jun 12 12:02:21 2020
 from setuptools import setup
 
 
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 
 # get the long description from the readme
 with open("README.md") as infile:


### PR DESCRIPTION
- allows stiching back fastqs
- corrects a logical error when umis are in separate fastqs. Pattern is not required as UMI are not extracted from the read.
 